### PR TITLE
Use interfaces and change names

### DIFF
--- a/contracts/RealitioProxy.sol
+++ b/contracts/RealitioProxy.sol
@@ -1,18 +1,18 @@
 pragma solidity ^0.5.12;
 
-contract ConditionalTokens {
+interface IConditionalTokens {
     function reportPayouts(bytes32 questionId, uint256[] calldata payouts) external;
 }
 
-contract Realitio {
+interface IRealitio {
     function resultFor(bytes32 questionId) external view returns (bytes32);
 }
 
 contract RealitioProxy {
-  ConditionalTokens public conditionalTokens;
-  Realitio public realitio;
+  IConditionalTokens public conditionalTokens;
+  IRealitio public realitio;
 
-  constructor(ConditionalTokens _conditionalTokens, Realitio _realitio) public {
+  constructor(IConditionalTokens _conditionalTokens, IRealitio _realitio) public {
     conditionalTokens = _conditionalTokens;
     realitio = _realitio;
   }

--- a/test/realitio_proxy.js
+++ b/test/realitio_proxy.js
@@ -1,7 +1,7 @@
 const abi = require('ethereumjs-abi')
 
 const RealitioProxy = artifacts.require('RealitioProxy')
-const ConditionalTokens = artifacts.require('ConditionalTokens')
+const ConditionalTokens = artifacts.require('IConditionalTokens')
 const MockContract = artifacts.require('MockContract.sol')
 
 contract('RealitioProxy', () => {


### PR DESCRIPTION
I have the original contracts in a project, and these names are causing some deployment issues.