### PR TITLE
Allow question type inference and add nuanced binary type

### DIFF
--- a/contracts/RealitioProxy.sol
+++ b/contracts/RealitioProxy.sol
@@ -5,6 +5,8 @@ interface IConditionalTokens {
 }
 
 interface IRealitio {
+    function getContentHash(bytes32 questionId) external view returns (bytes32);
+    function getOpeningTS(bytes32 questionId) external view returns (uint32);
     function resultFor(bytes32 questionId) external view returns (bytes32);
 }
 
@@ -17,15 +19,42 @@ contract RealitioProxy {
     realitio = _realitio;
   }
 
-  function resolveSingleSelectCondition(bytes32 questionId, uint256 numOutcomes) public {
-    uint256 answer = uint256(realitio.resultFor(questionId));
+  function resolve(
+    bytes32 questionId,
+    uint256 templateId,
+    string calldata question,
+    uint256 numOutcomes
+  ) external {
+    // check that the given templateId and question match the questionId
+    bytes32 contentHash = keccak256(abi.encodePacked(templateId, realitio.getOpeningTS(questionId), question));
+    require(contentHash == realitio.getContentHash(questionId), "Content hash mismatch");
 
-    require(answer < numOutcomes, "Answer must be between 0 and numOutcomes");
+    uint256[] memory payouts;
 
-    uint256[] memory payouts = new uint256[](numOutcomes);
-
-    payouts[answer] = 1;
+    if (templateId == 0 || templateId == 2) {
+      // binary or single-select
+      payouts = getSingleSelectPayouts(questionId, numOutcomes);
+    } else {
+      revert("Unknown templateId");
+    }
 
     conditionalTokens.reportPayouts(questionId, payouts);
+  }
+
+  function getSingleSelectPayouts(bytes32 questionId, uint256 numOutcomes) internal view returns (uint256[] memory) {
+    uint256[] memory payouts = new uint256[](numOutcomes);
+
+    uint256 answer = uint256(realitio.resultFor(questionId));
+
+    if (answer == uint256(-1)) {
+      for (uint256 i = 0; i < numOutcomes; i++) {
+        payouts[i] = 1;
+      }
+    } else {
+      require(answer < numOutcomes, "Answer must be between 0 and numOutcomes");
+      payouts[answer] = 1;
+    }
+
+    return payouts;
   }
 }

--- a/test/realitio_proxy.js
+++ b/test/realitio_proxy.js
@@ -16,7 +16,8 @@ contract('RealitioProxy', () => {
 
       const realitioProxy = await RealitioProxy.new(
         conditionalTokensMock.address,
-        realitioMock.address
+        realitioMock.address,
+        7,
       )
 
       let failed = false
@@ -68,7 +69,8 @@ contract('RealitioProxy', () => {
 
       const realitioProxy = await RealitioProxy.new(
         conditionalTokensMock.address,
-        realitioMock.address
+        realitioMock.address,
+        7,
       )
       await realitioProxy.resolve(questionId, 2, 'question data', 3)
 
@@ -127,7 +129,8 @@ contract('RealitioProxy', () => {
 
       const realitioProxy = await RealitioProxy.new(
         conditionalTokensMock.address,
-        realitioMock.address
+        realitioMock.address,
+        7,
       )
       await realitioProxy.resolve(questionId, 2, 'question data', 3)
 
@@ -186,7 +189,8 @@ contract('RealitioProxy', () => {
 
       const realitioProxy = await RealitioProxy.new(
         conditionalTokensMock.address,
-        realitioMock.address
+        realitioMock.address,
+        7,
       )
       await realitioProxy.resolve(questionId, 2, 'question data', 3)
 
@@ -245,7 +249,8 @@ contract('RealitioProxy', () => {
 
       const realitioProxy = await RealitioProxy.new(
         conditionalTokensMock.address,
-        realitioMock.address
+        realitioMock.address,
+        7,
       )
 
       let failed = false
@@ -298,7 +303,8 @@ contract('RealitioProxy', () => {
 
       const realitioProxy = await RealitioProxy.new(
         conditionalTokensMock.address,
-        realitioMock.address
+        realitioMock.address,
+        7,
       )
 
       let failed = false
@@ -351,7 +357,8 @@ contract('RealitioProxy', () => {
 
       const realitioProxy = await RealitioProxy.new(
         conditionalTokensMock.address,
-        realitioMock.address
+        realitioMock.address,
+        7,
       )
 
       await realitioProxy.resolve(questionId, 2, 'question data', 3)
@@ -359,6 +366,446 @@ contract('RealitioProxy', () => {
       const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
       const reportPayoutsAbi = conditionalTokens.contract.methods
         .reportPayouts(questionId, [1, 1, 1])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+  })
+
+  describe('nuanced binary', () => {
+    it('should revert if the question has not been finalized', async () => {
+      const realitioMock = await MockContract.new()
+      await realitioMock.givenAnyRevert()
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+
+      let failed = false
+      try {
+        await realitioProxy.resolve('0x0', 7, 'question data', 2)
+      } catch (e) {
+        failed = true
+      }
+
+      assert(failed)
+    })
+
+    it('should succeed if the question has been finalized with 0', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 7 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000000']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+      await realitioProxy.resolve(questionId, 7, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [4, 0])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+
+    it('should succeed if the question has been finalized with 1', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 7 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000001']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+      await realitioProxy.resolve(questionId, 7, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [3, 1])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+
+    it('should succeed if the question has been finalized with 2', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 7 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000002']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+      await realitioProxy.resolve(questionId, 7, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [2, 2])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+
+    it('should succeed if the question has been finalized with 3', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 7 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000003']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+      await realitioProxy.resolve(questionId, 7, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [1, 3])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+
+    it('should succeed if the question has been finalized with 4', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 7 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000004']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+      await realitioProxy.resolve(questionId, 7, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [0, 4])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+
+    it('should revert if the answer is out of range', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 7 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000005']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+
+      let failed = false
+      try {
+        await realitioProxy.resolve(questionId, 7, 'question data', 2)
+      } catch (e) {
+        failed = true
+        assert(e.message.includes('Answer must be between 0 and 4'))
+      }
+
+      assert(failed)
+    })
+
+    it('should give even payouts if answer is invalid', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 7 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+
+      await realitioProxy.resolve(questionId, 7, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [1, 1])
         .encodeABI()
 
       // check that report payouts was called only once

--- a/test/realitio_proxy.js
+++ b/test/realitio_proxy.js
@@ -6,6 +6,266 @@ const ConditionalTokens = artifacts.require('IConditionalTokens')
 const MockContract = artifacts.require('MockContract.sol')
 
 contract('RealitioProxy', () => {
+  describe('binary', () => {
+    it('should revert if the question has not been finalized', async () => {
+      const realitioMock = await MockContract.new()
+      await realitioMock.givenAnyRevert()
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+
+      let failed = false
+      try {
+        await realitioProxy.resolve('0x0', 0, 'question data', 2)
+      } catch (e) {
+        failed = true
+      }
+
+      assert(failed)
+    })
+
+    it('should succeed if the question has been finalized with 0', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 0 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000000']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+      await realitioProxy.resolve(questionId, 0, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [1, 0])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+
+    it('should succeed if the question has been finalized with 1', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 0 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000001']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+      await realitioProxy.resolve(questionId, 0, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [0, 1])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+
+    it('should revert if the answer is out of range', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 0 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000002']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+
+      let failed = false
+      try {
+        await realitioProxy.resolve(questionId, 0, 'question data', 2)
+      } catch (e) {
+        failed = true
+        assert(e.message.includes('Answer must be between 0 and numOutcomes'))
+      }
+
+      assert(failed)
+    })
+
+    it('should give even payouts if answer is invalid', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 0 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+
+      await realitioProxy.resolve(questionId, 0, 'question data', 2)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [1, 1])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
+    })
+  })
+
   describe('single select', () => {
     it('should revert if the question has not been finalized', async () => {
       const realitioMock = await MockContract.new()
@@ -818,5 +1078,59 @@ contract('RealitioProxy', () => {
       )
       assert.equal(callWithArgsCount.toString(), 1)
     })
+  })
+
+  it('should revert if the templateId is not known', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 10 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0x0000000000000000000000000000000000000000000000000000000000000000']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address,
+        7,
+      )
+
+      let failed = false
+      try {
+        await realitioProxy.resolve(questionId, 10, 'question data', 2)
+      } catch (e) {
+        failed = true
+        assert(e.message.includes('Unknown templateId'))
+      }
+
+      assert(failed)
   })
 })

--- a/test/realitio_proxy.js
+++ b/test/realitio_proxy.js
@@ -1,6 +1,7 @@
 const abi = require('ethereumjs-abi')
 
 const RealitioProxy = artifacts.require('RealitioProxy')
+const Realitio = artifacts.require('IRealitio')
 const ConditionalTokens = artifacts.require('IConditionalTokens')
 const MockContract = artifacts.require('MockContract.sol')
 
@@ -20,7 +21,7 @@ contract('RealitioProxy', () => {
 
       let failed = false
       try {
-        await realitioProxy.resolveSingleSelectCondition('0x0', 3)
+        await realitioProxy.resolve('0x0', 2, 'question data', 3)
       } catch (e) {
         failed = true
       }
@@ -31,7 +32,31 @@ contract('RealitioProxy', () => {
     it('should succeed if the question has been finalized with 0', async () => {
       const questionId = '0x1234567890'
       const realitioMock = await MockContract.new()
-      await realitioMock.givenAnyReturn(
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 2 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
         abi.rawEncode(
           ['bytes32'],
           ['0x0000000000000000000000000000000000000000000000000000000000000000']
@@ -45,7 +70,7 @@ contract('RealitioProxy', () => {
         conditionalTokensMock.address,
         realitioMock.address
       )
-      await realitioProxy.resolveSingleSelectCondition(questionId, 3)
+      await realitioProxy.resolve(questionId, 2, 'question data', 3)
 
       const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
       const reportPayoutsAbi = conditionalTokens.contract.methods
@@ -66,7 +91,31 @@ contract('RealitioProxy', () => {
     it('should succeed if the question has been finalized with 1', async () => {
       const questionId = '0x1234567890'
       const realitioMock = await MockContract.new()
-      await realitioMock.givenAnyReturn(
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 2 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
         abi.rawEncode(
           ['bytes32'],
           ['0x0000000000000000000000000000000000000000000000000000000000000001']
@@ -80,7 +129,7 @@ contract('RealitioProxy', () => {
         conditionalTokensMock.address,
         realitioMock.address
       )
-      await realitioProxy.resolveSingleSelectCondition(questionId, 3)
+      await realitioProxy.resolve(questionId, 2, 'question data', 3)
 
       const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
       const reportPayoutsAbi = conditionalTokens.contract.methods
@@ -101,7 +150,31 @@ contract('RealitioProxy', () => {
     it('should succeed if the question has been finalized with 2', async () => {
       const questionId = '0x1234567890'
       const realitioMock = await MockContract.new()
-      await realitioMock.givenAnyReturn(
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 2 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
         abi.rawEncode(
           ['bytes32'],
           ['0x0000000000000000000000000000000000000000000000000000000000000002']
@@ -115,7 +188,7 @@ contract('RealitioProxy', () => {
         conditionalTokensMock.address,
         realitioMock.address
       )
-      await realitioProxy.resolveSingleSelectCondition(questionId, 3)
+      await realitioProxy.resolve(questionId, 2, 'question data', 3)
 
       const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
       const reportPayoutsAbi = conditionalTokens.contract.methods
@@ -136,7 +209,31 @@ contract('RealitioProxy', () => {
     it('should revert if the answer is equal to the number of outcomes', async () => {
       const questionId = '0x1234567890'
       const realitioMock = await MockContract.new()
-      await realitioMock.givenAnyReturn(
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 2 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
         abi.rawEncode(
           ['bytes32'],
           ['0x0000000000000000000000000000000000000000000000000000000000000003']
@@ -153,7 +250,7 @@ contract('RealitioProxy', () => {
 
       let failed = false
       try {
-        await realitioProxy.resolveSingleSelectCondition(questionId, 3)
+        await realitioProxy.resolve(questionId, 2, 'question data', 3)
       } catch (e) {
         failed = true
         assert(e.message.includes('Answer must be between 0 and numOutcomes'))
@@ -165,7 +262,31 @@ contract('RealitioProxy', () => {
     it('should revert if the answer is greater than the number of outcomes', async () => {
       const questionId = '0x1234567890'
       const realitioMock = await MockContract.new()
-      await realitioMock.givenAnyReturn(
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 2 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
         abi.rawEncode(
           ['bytes32'],
           ['0x0000000000000000000000000000000000000000000000000000000000000004']
@@ -182,13 +303,73 @@ contract('RealitioProxy', () => {
 
       let failed = false
       try {
-        await realitioProxy.resolveSingleSelectCondition(questionId, 3)
+        await realitioProxy.resolve(questionId, 2, 'question data', 3)
       } catch (e) {
         failed = true
         assert(e.message.includes('Answer must be between 0 and numOutcomes'))
       }
 
       assert(failed)
+    })
+
+    it('should give even payouts if answer is invalid', async () => {
+      const questionId = '0x1234567890'
+      const realitioMock = await MockContract.new()
+      const realitio = await Realitio.at(realitioMock.address)
+
+      const getContentHash = realitio.contract.methods.getContentHash('0x').encodeABI()
+      const getOpeningTS = realitio.contract.methods.getOpeningTS('0x').encodeABI()
+      const resultFor = realitio.contract.methods.resultFor('0x').encodeABI()
+
+      await realitioMock.givenMethodReturn(
+        getContentHash,
+        abi.rawEncode(
+          ['bytes32'],
+          [web3.utils.soliditySha3(
+            { t: 'uint256', v: 2 },
+            { t: 'uint32', v: 0 },
+            { t: 'string', v: 'question data' },
+          )]
+        )
+      )
+
+      await realitioMock.givenMethodReturn(
+        getOpeningTS,
+        abi.rawEncode(['uint32'], [0])
+      )
+
+      await realitioMock.givenMethodReturn(
+        resultFor,
+        abi.rawEncode(
+          ['bytes32'],
+          ['0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff']
+        )
+      )
+
+      const conditionalTokensMock = await MockContract.new()
+      await conditionalTokensMock.givenAnyReturnBool(true)
+
+      const realitioProxy = await RealitioProxy.new(
+        conditionalTokensMock.address,
+        realitioMock.address
+      )
+
+      await realitioProxy.resolve(questionId, 2, 'question data', 3)
+
+      const conditionalTokens = await ConditionalTokens.at(conditionalTokensMock.address)
+      const reportPayoutsAbi = conditionalTokens.contract.methods
+        .reportPayouts(questionId, [1, 1, 1])
+        .encodeABI()
+
+      // check that report payouts was called only once
+      const callCount = await conditionalTokensMock.invocationCountForMethod.call(reportPayoutsAbi)
+      assert.equal(callCount.toString(), 1)
+
+      // check that report payouts was called with the correct arguments
+      const callWithArgsCount = await conditionalTokensMock.invocationCountForCalldata.call(
+        reportPayoutsAbi
+      )
+      assert.equal(callWithArgsCount.toString(), 1)
     })
   })
 })


### PR DESCRIPTION
Assumes a new template ID that expects a result from 0 to 4, where 0 is full payout in the first slot, 4 is full payout in the second slot, and results in between steps payouts in quarters.

Invalid also causes payouts to be set evenly, similar to reporting 2.

Finally, results outside the expected range (other than invalid) cause a revert, and payouts to be stuck.